### PR TITLE
fix: disable Git SSL verified

### DIFF
--- a/pkg/topology/store/store.go
+++ b/pkg/topology/store/store.go
@@ -78,7 +78,7 @@ func New(ctx context.Context, cfg Config) (*Store, error) {
 
 func (s *Store) cloneRepository(ctx context.Context) error {
 	if disableGitSSLVerify() {
-		output, err := git.Config(config.Global, config.Add("http.sslVerify", "false"), clone.Depth("1"), clone.NoSingleBranch)
+		output, err := git.Config(config.Global, config.Add("http.sslVerify", "false"))
 		if err != nil {
 			return fmt.Errorf("%w: %s", err, output)
 		}


### PR DESCRIPTION
### Description 

This PR fixes agent when `DISABLE_GIT_SSL_VERIFY` exists.